### PR TITLE
language and position attributes io32/115

### DIFF
--- a/modern/src/common/attributes/usePositionAttributes.js
+++ b/modern/src/common/attributes/usePositionAttributes.js
@@ -104,6 +104,14 @@ export default (t) => useMemo(() => ({
     name: t('positionRssi'),
     type: 'number',
   },
+  coolantTemp: {
+    name: t('positionCoolantTemp'),
+    type: 'number',
+  },
+  engineTemp: {
+    name: t('positionEngineTemp'),
+    type: 'number',
+  },
   gps: {
     name: t('positionGps'),
     type: 'number',

--- a/modern/src/common/components/PositionValue.js
+++ b/modern/src/common/components/PositionValue.js
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { Link } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import {
-  formatAlarm, formatAltitude, formatBoolean, formatCoordinate, formatCourse, formatDistance, formatNumber, formatNumericHours, formatPercentage, formatSpeed, formatTime,
+  formatAlarm, formatAltitude, formatBoolean, formatCoordinate, formatCourse, formatDistance, formatNumber, formatNumericHours, formatPercentage, formatSpeed, formatTime, formatCelsius,
 } from '../util/formatter';
 import { useAttributePreference, usePreference } from '../util/preferences';
 import { useTranslation } from './LocalizationProvider';
@@ -53,6 +53,10 @@ const PositionValue = ({ position, property, attribute }) => {
         return value != null ? formatDistance(value, distanceUnit, t) : '';
       case 'hours':
         return value != null ? formatNumericHours(value, t) : '';
+      case 'coolantTemp':
+        return formatCelsius(value);
+      case 'engineTemp':
+        return formatCelsius(value);
       default:
         if (typeof value === 'number') {
           return formatNumber(value);

--- a/modern/src/common/util/formatter.js
+++ b/modern/src/common/util/formatter.js
@@ -17,6 +17,8 @@ export const formatNumber = (value, precision = 1) => Number(value.toFixed(preci
 
 export const formatPercentage = (value) => `${value}%`;
 
+export const formatCelsius = (value) => `${value}°C`;
+
 export const formatTime = (value, format, hours12) => {
   if (value) {
     const m = moment(value);

--- a/modern/src/resources/l10n/af.json
+++ b/modern/src/resources/l10n/af.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Enjinsemperatuur",
+    "positionCoolantTemp": "Koelmiddel temperatuur",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Toestel Tyd",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/ar.json
+++ b/modern/src/resources/l10n/ar.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "درجة حرارة المحرك",
+    "positionCoolantTemp": "حرارة المبرد",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/az.json
+++ b/modern/src/resources/l10n/az.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Mühərrikin temperaturu",
+    "positionCoolantTemp": "Soyuducu temperaturu",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/bg.json
+++ b/modern/src/resources/l10n/bg.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Температура на двигателя",
+    "positionCoolantTemp": "Температура на охлаждащата течност",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/bn.json
+++ b/modern/src/resources/l10n/bn.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "ইঞ্জিন তাপমাত্রা",
+    "positionCoolantTemp": "কমতে থাকা তাপমাত্রা",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/ca.json
+++ b/modern/src/resources/l10n/ca.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura del motor",
+    "positionCoolantTemp": "Temperatura del refrigerant",
     "positionFixTime": "Hora registrada",
     "positionDeviceTime": "Hora del Dispositiu",
     "positionServerTime": "Hora del Servidor",

--- a/modern/src/resources/l10n/cs.json
+++ b/modern/src/resources/l10n/cs.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Teplota motoru",
+    "positionCoolantTemp": "Teplota chladicí kapaliny",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/da.json
+++ b/modern/src/resources/l10n/da.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Motor temperatur",
+    "positionCoolantTemp": "Kølevæsketemperatur",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/de.json
+++ b/modern/src/resources/l10n/de.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperaturtemperatur",
+    "positionCoolantTemp": "Kühlmitteltemperatur",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Gerätezeit",
     "positionServerTime": "Serverzeit",

--- a/modern/src/resources/l10n/el.json
+++ b/modern/src/resources/l10n/el.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Χάρτες Google",
     "linkAppleMaps": "Χάρτες Apple",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Θερμοκρασία κινητήρα",
+    "positionCoolantTemp": "Θερμοκρασία ψυκτικού",
     "positionFixTime": "Διόρθωση χρόνου",
     "positionDeviceTime": "Χρόνος συσκευής",
     "positionServerTime": "Χρόνος Διακομιστή",

--- a/modern/src/resources/l10n/en.json
+++ b/modern/src/resources/l10n/en.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Engine Temperature",
+    "positionCoolantTemp": "Coolant Temperature",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/es.json
+++ b/modern/src/resources/l10n/es.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura del motor",
+    "positionCoolantTemp": "Temperatura refrescante",
     "positionFixTime": "Hora ajustada",
     "positionDeviceTime": "Hora del dispositivo",
     "positionServerTime": "Hora del Servidor",

--- a/modern/src/resources/l10n/fa.json
+++ b/modern/src/resources/l10n/fa.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "نقشه گوگل",
     "linkAppleMaps": "نقشه اپل",
     "linkStreetView": "نمای خیابان",
+    "positionEngineTemp": "دمای موتور",
+    "positionCoolantTemp": "دمای خنک کننده",
     "positionFixTime": "زمان ثابت",
     "positionDeviceTime": "زمان دستگاه",
     "positionServerTime": "زمان سرور",

--- a/modern/src/resources/l10n/fi.json
+++ b/modern/src/resources/l10n/fi.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google kartat",
     "linkAppleMaps": "Apple kartat",
     "linkStreetView": "Katunäkymä",
+    "positionEngineTemp": "Moottorin lämpötila",
+    "positionCoolantTemp":"Jäähdytysnesteen lämpötila",
     "positionFixTime": "Sijaintiaika",
     "positionDeviceTime": "Laitteen aika",
     "positionServerTime": "Palvelimen aika",

--- a/modern/src/resources/l10n/fr.json
+++ b/modern/src/resources/l10n/fr.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Plans",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Température du moteur",
+    "positionCoolantTemp": "Température du liquide de refroidissement",
     "positionFixTime": "Horodatage",
     "positionDeviceTime": "Heure de l'appareil",
     "positionServerTime": "Heure du serveur",

--- a/modern/src/resources/l10n/gl.json
+++ b/modern/src/resources/l10n/gl.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura do motor",
+    "positionCoolantTemp": "Temperatura do refrixerante",
     "positionFixTime": "Hora axustada",
     "positionDeviceTime": "Hora do dispositivo",
     "positionServerTime": "Hora do servidor",

--- a/modern/src/resources/l10n/he.json
+++ b/modern/src/resources/l10n/he.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "טמפרטורת המנוע",
+    "positionCoolantTemp": "טמפרטורת נוזל קירור",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/hi.json
+++ b/modern/src/resources/l10n/hi.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "इंजन तापमान",
+    "positionCoolantTemp": "शीतलक तापमान",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/hr.json
+++ b/modern/src/resources/l10n/hr.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura motora",
+    "positionCoolantTemp": "Temperatura rashladne tekućine",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/hu.json
+++ b/modern/src/resources/l10n/hu.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Motorhőmérséklet",
+    "positionCoolantTemp": "Hűtőfolyadék -hőmérséklet",
     "positionFixTime": "Idő beállítás",
     "positionDeviceTime": "Eszköz idő",
     "positionServerTime": "Szerver idő",

--- a/modern/src/resources/l10n/id.json
+++ b/modern/src/resources/l10n/id.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Suhu mesin",
+    "positionCoolantTemp": "Suhu pendingin",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/it.json
+++ b/modern/src/resources/l10n/it.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura del motore",
+    "positionCoolantTemp": "Temperatura del refrigerante",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/ja.json
+++ b/modern/src/resources/l10n/ja.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Googleマップ",
     "linkAppleMaps": "Appleマップ",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "エンジン温度",
+    "positionCoolantTemp": "クーラント温度",
     "positionFixTime": "固定日時",
     "positionDeviceTime": "デバイスの時刻",
     "positionServerTime": "サーバーの時刻",

--- a/modern/src/resources/l10n/ka.json
+++ b/modern/src/resources/l10n/ka.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "ძრავის ტემპერატურა",
+    "positionCoolantTemp": "გამაგრილებლის ტემპერატურა",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/kk.json
+++ b/modern/src/resources/l10n/kk.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Қозғалтқыш температурасы",
+    "positionCoolantTemp": "Салқындатқыш температурасы",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/km.json
+++ b/modern/src/resources/l10n/km.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "សីតុណ្ហាភាពម៉ាស៊ីន",
+    "positionCoolantTemp": "សីតុណ្ហភាពត្រជាក់",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/ko.json
+++ b/modern/src/resources/l10n/ko.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "엔진 온도",
+    "positionCoolantTemp": "냉각수 온도",
     "positionFixTime": "Fix 시간",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/lo.json
+++ b/modern/src/resources/l10n/lo.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "ອຸນຫະພູມຂອງເຄື່ອງຈັກ",
+    "positionCoolantTemp": "ອຸນຫະພູມເຢັນ",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/lt.json
+++ b/modern/src/resources/l10n/lt.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google žemėlapiai",
     "linkAppleMaps": "Apple žemėlapiai",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Variklio temperatūra",
+    "positionCoolantTemp":"Aušinimo skysčio temperatūra",
     "positionFixTime": "Fiksuoti laiką",
     "positionDeviceTime": "Įrenginio laikas",
     "positionServerTime": "Serverio laikas",

--- a/modern/src/resources/l10n/lv.json
+++ b/modern/src/resources/l10n/lv.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google kartes",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Ielas skats",
+    "positionEngineTemp": "Motora temperatūra",
+    "positionCoolantTemp": "Dzesēšanas šķidruma temperatūra",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Ierīces laiks",
     "positionServerTime": "Servera Laiks",

--- a/modern/src/resources/l10n/ml.json
+++ b/modern/src/resources/l10n/ml.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "എഞ്ചിൻ താപനില",
+    "positionCoolantTemp": "കൂളന്റ് താപനില",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/mn.json
+++ b/modern/src/resources/l10n/mn.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Хандаргийн температур",
+    "positionCoolantTemp": "Хөргөх хүйс",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/ms.json
+++ b/modern/src/resources/l10n/ms.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Suhu enjin",
+    "positionCoolantTemp": "Suhu penyejuk",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/nb.json
+++ b/modern/src/resources/l10n/nb.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Motortemperatur",
+    "positionCoolantTemp": "Kjølevæsketemperatur",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/ne.json
+++ b/modern/src/resources/l10n/ne.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "गुगल नक्शा",
     "linkAppleMaps": "एप्पल नक्शा",
     "linkStreetView": "सडक दृश्य",
+    "positionEngineTemp": "इन्जिन तापक्रम",
+    "positionCoolantTemp": "कोूलन्ट तापक्रम",
     "positionFixTime": "समय तय गर्नुहोस्",
     "positionDeviceTime": "उपकरण समय",
     "positionServerTime": "सर्भर समय",

--- a/modern/src/resources/l10n/nl.json
+++ b/modern/src/resources/l10n/nl.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Motortemperatuur",
+    "positionCoolantTemp": "Koelvloeistoftemperatuur",
     "positionFixTime": "Tijd aanpassen",
     "positionDeviceTime": "Tijd van apparaat",
     "positionServerTime": "Tijd van server",

--- a/modern/src/resources/l10n/nn.json
+++ b/modern/src/resources/l10n/nn.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Motortemperatur",
+    "positionCoolantTemp": "Kjølevæsketemperatur",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/pl.json
+++ b/modern/src/resources/l10n/pl.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Mapy Google",
     "linkAppleMaps": "Mapy Apple",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura silnika",
+    "positionCoolantTemp": "Temperatura płynu chłodzącego",
     "positionFixTime": "Czas ustalenia pozycji",
     "positionDeviceTime": "Czas urządzenia",
     "positionServerTime": "Czas serwera",

--- a/modern/src/resources/l10n/pt.json
+++ b/modern/src/resources/l10n/pt.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura do motor",
+    "positionCoolantTemp": "Temperatura do líquido de arrefecimento",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/ro.json
+++ b/modern/src/resources/l10n/ro.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura motorului",
+    "positionCoolantTemp": "Temperatura agentului de răcire",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/ru.json
+++ b/modern/src/resources/l10n/ru.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Карты Google",
     "linkAppleMaps": "Карты Apple",
     "linkStreetView": "Просмотр улиц",
+    "positionEngineTemp": "Температура двигателя",
+    "positionCoolantTemp": "Температура охлаждающей жидкости",
     "positionFixTime": "Время определения",
     "positionDeviceTime": "Время на устройстве",
     "positionServerTime": "Время на сервере",

--- a/modern/src/resources/l10n/si.json
+++ b/modern/src/resources/l10n/si.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "ගුගල් සිතියම්",
     "linkAppleMaps": "ඇපල් සිතියම්",
     "linkStreetView": "වීථි දසුන",
+    "positionEngineTemp": "එන්ජින් උෂ්ණත්වය",
+    "positionCoolantTemp": "සිසිලන උෂ්ණත්වය",
     "positionFixTime": "කාලය නිවැරදි කරන්න",
     "positionDeviceTime": "උපාංග කාලය",
     "positionServerTime": "සේවාදායක කාලය",

--- a/modern/src/resources/l10n/sk.json
+++ b/modern/src/resources/l10n/sk.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Teplota motora",
+    "positionCoolantTemp": "Teplota chladiacej kvapaliny",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/sl.json
+++ b/modern/src/resources/l10n/sl.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura motorja",
+    "positionCoolantTemp": "Temperatura hladilne tekočine",
     "positionFixTime": "Čas določitve",
     "positionDeviceTime": "Čas naprave",
     "positionServerTime": "Čas strežnika",

--- a/modern/src/resources/l10n/sq.json
+++ b/modern/src/resources/l10n/sq.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Temperatura e motorit",
+    "positionCoolantTemp": "Temperatura e ftohësit",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/sr.json
+++ b/modern/src/resources/l10n/sr.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Mape",
     "linkAppleMaps": "Apple Mape",
     "linkStreetView": "Pogled na ulicu",
+    "positionEngineTemp": "Температура мотора",
+    "positionCoolantTemp": "Температура расхладне течности",
     "positionFixTime": "Vreme javljanja",
     "positionDeviceTime": "Vreme na uređaju",
     "positionServerTime": "Vreme na serveru",

--- a/modern/src/resources/l10n/sv.json
+++ b/modern/src/resources/l10n/sv.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Gatuvy",
+    "positionEngineTemp": "Motortemperatur",
+    "positionCoolantTemp": "Kylvätsketemperatur",
     "positionFixTime": "Låst tid",
     "positionDeviceTime": "Enhetstid",
     "positionServerTime": "Servertid",

--- a/modern/src/resources/l10n/ta.json
+++ b/modern/src/resources/l10n/ta.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "இயந்திர வெப்பநிலை",
+    "positionCoolantTemp": "குளிரூட்டும் வெப்பநிலை",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/th.json
+++ b/modern/src/resources/l10n/th.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "อุณหภูมิเครื่องยนต์",
+    "positionCoolantTemp": "อุณหภูมิน้ำหล่อเย็น",
     "positionFixTime": "แก้ไขเวลา",
     "positionDeviceTime": "เวลาอุปกรณ์",
     "positionServerTime": "เวลาเซิร์ฟเวอร์",

--- a/modern/src/resources/l10n/tr.json
+++ b/modern/src/resources/l10n/tr.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Motor sıcaklığı",
+    "positionCoolantTemp": "Soğutucu Sıcaklığı",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Cihaz Saati",
     "positionServerTime": "Sunucu zamanı",

--- a/modern/src/resources/l10n/uk.json
+++ b/modern/src/resources/l10n/uk.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Температура двигуна",
+    "positionCoolantTemp": "Температура теплоносія",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/uz.json
+++ b/modern/src/resources/l10n/uz.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Dvigatel harorati",
+    "positionCoolantTemp": "Sovutish harorati",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/vi.json
+++ b/modern/src/resources/l10n/vi.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "Google Maps",
     "linkAppleMaps": "Apple Maps",
     "linkStreetView": "Street View",
+    "positionEngineTemp": "Nhiệt độ động cơ",
+    "positionCoolantTemp": "Nhiệt độ làm mát",
     "positionFixTime": "Fix Time",
     "positionDeviceTime": "Device Time",
     "positionServerTime": "Server Time",

--- a/modern/src/resources/l10n/zh.json
+++ b/modern/src/resources/l10n/zh.json
@@ -231,6 +231,8 @@
     "linkGoogleMaps": "谷歌地图",
     "linkAppleMaps": "苹果地图",
     "linkStreetView": "街景",
+    "positionEngineTemp": "发动机温度",
+    "positionCoolantTemp": "冷却液温度",
     "positionFixTime": "修正时间",
     "positionDeviceTime": "设备时间",
     "positionServerTime": "服务器时间",


### PR DESCRIPTION
Change to Teltonika decode as coolant temperature was being decoded wrong. Previously decoded as io115 (engine temperature) but now corrected to io32 (coolant temperature) with io115 also being decoded correctly now.
